### PR TITLE
Removing tzinfo-replace

### DIFF
--- a/custom_components/ical/sensor.py
+++ b/custom_components/ical/sensor.py
@@ -77,8 +77,11 @@ def dateparser(calendar, date):
                 end = arrow.get(event['DTEND'].dt)
             else:
                 end = event['DTEND'].dt
-            event_dict['end'] = end
+                event_dict['end'] = end
 
+        if 'LOCATION' in event:
+            event_dict['location'] = event['LOCATION']
+        
         events.append(event_dict)
 
     sorted_events = sorted(events, key=lambda k: k['start'])
@@ -136,7 +139,8 @@ class ICalSensor(Entity):
         self._event_attributes = {
             'name': None,
             'start': None,
-            'end': None
+            'end': None,
+            'location': None
         }
         # Get the data
         self.data_object.update()
@@ -146,6 +150,10 @@ class ICalSensor(Entity):
             val = event_list[self._eventno]
             start = val['start'].datetime
             self._event_attributes['start'] = start
+            end = val['end'].datetime
+            self._event_attributes['end'] = end
+            location = val.get('location', '')
+            self._event_attributes['location'] = location
             name = val.get('name', 'unknown')
             self._event_attributes['name'] = name
             self._state = "{} - {}".format(

--- a/custom_components/ical/sensor.py
+++ b/custom_components/ical/sensor.py
@@ -60,7 +60,6 @@ def dateparser(calendar, date):
 
         if isinstance(event['DTSTART'].dt, dt.date):
             start = arrow.get(event['DTSTART'].dt)
-            start = start.replace(tzinfo='local')
         else:
             start = event['DTSTART'].dt
 
@@ -76,7 +75,6 @@ def dateparser(calendar, date):
         if 'DTEND' in event:
             if isinstance(event['DTEND'].dt, dt.date):
                 end = arrow.get(event['DTEND'].dt)
-                end = end.replace(tzinfo='local')
             else:
                 end = event['DTEND'].dt
             event_dict['end'] = end


### PR DESCRIPTION
It caused all my events to be forced to the wrong TZ.  Seems like TZ-handing in icaledar is quite good now, so it works better without them.
Tested with both Microsoft and Google calendars