### PR TITLE
Update for all day events

### DIFF
--- a/custom_components/ical/__init__.py
+++ b/custom_components/ical/__init__.py
@@ -193,6 +193,7 @@ class ICalEvents:
 
                 # If we don't have a DTEND, just use DTSTART
                 if "DTEND" not in event:
+
                     dtend = dtstart
                 else:
                     _LOGGER.debug("DTEND in rrule: %s", str(event["DTEND"].dt))
@@ -329,7 +330,15 @@ class ICalEvents:
                 start = dtstart
 
                 if "DTEND" not in event:
-                    dtend = dtstart
+                    _LOGGER.debug("Event found without end datetime")
+                    if self.all_day:
+                        # if it's an all day event with no endtime listed, we'll assume it ends at 23:59:59
+                        _LOGGER.debug(f"Event {event['SUMMARY']} is flagged as all day, with a start time of {start}.")
+                        dtend = dtstart + timedelta(days=1, seconds=-1)
+                        _LOGGER.debug(f"Setting the end time to {dtend}")
+                    else:
+                        _LOGGER.debug(f"Event {event['SUMMARY']} doesn't have an end but isn't flagged as all day.")
+                        dtend = dtstart
                 else:
                     _LOGGER.debug("DTEND in event")
                     dtend = self._ical_date_fixer(

--- a/custom_components/ical/__init__.py
+++ b/custom_components/ical/__init__.py
@@ -191,12 +191,18 @@ class ICalEvents:
                     event["DTSTART"].dt, dt.DEFAULT_TIME_ZONE
                 )
 
-                # If we don't have a DTEND, just use DTSTART
                 if "DTEND" not in event:
-
-                    dtend = dtstart
+                    _LOGGER.debug("Event found without end datetime")
+                    if self.all_day:
+                        # if it's an all day event with no endtime listed, we'll assume it ends at 23:59:59
+                        _LOGGER.debug(f"Event {event['SUMMARY']} is flagged as all day, with a start time of {start}.")
+                        dtend = dtstart + timedelta(days=1, seconds=-1)
+                        _LOGGER.debug(f"Setting the end time to {dtend}")
+                    else:
+                        _LOGGER.debug(f"Event {event['SUMMARY']} doesn't have an end but isn't flagged as all day.")
+                        dtend = dtstart
                 else:
-                    _LOGGER.debug("DTEND in rrule: %s", str(event["DTEND"].dt))
+                    _LOGGER.debug("DTEND in event")
                     dtend = self._ical_date_fixer(
                         event["DTEND"].dt, dt.DEFAULT_TIME_ZONE
                     )

--- a/custom_components/ical/manifest.json
+++ b/custom_components/ical/manifest.json
@@ -12,9 +12,9 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/tybritten/ical-sensor-homeassistant/issues",
   "requirements": [
-    "icalendar==5.0.4"
+    "icalendar==5.0.7"
   ],
   "ssdp": [],
-  "version": "1.6.6",
+  "version": "1.6.7",
   "zeroconf": []
 }

--- a/ical_updater.json
+++ b/ical_updater.json
@@ -1,7 +1,7 @@
 {
     "sensor.ical": {
-      "updated_at": "2023-03-38",
-      "version": "1.6.6",
+      "updated_at": "2023-08-28",
+      "version": "1.6.7",
       "local_location": "/custom_components/ics/__init__.py",
       "remote_location": "https://raw.githubusercontent.com/tybritten/ical-sensor-homeassistant/master/__init__.py",
       "visit_repo": "https://github.com/tybritten/ical-sensor-homeassistant/",


### PR DESCRIPTION
This changes the behavior for all day events that don't have a DTEND. Today, if there's no DTEND we set it the same as the start. The problem is, that day, the all-day event disappears (since the end is the same as the start, midnight). This change checks to see if the event is flagged as all_day, and then sets the end time to 23:59:59 to avoid this.

