### PR TITLE
Replace deprecated async_forward_entry_setup call

### DIFF
--- a/custom_components/ical/__init__.py
+++ b/custom_components/ical/__init__.py
@@ -49,10 +49,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         hass.data[DOMAIN] = {}
     hass.data[DOMAIN][config.get(CONF_NAME)] = ICalEvents(hass=hass, config=config)
 
-    for component in PLATFORMS:
-        hass.async_create_task(
-            hass.config_entries.async_forward_entry_setup(entry, component)
-        )
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     return True
 


### PR DESCRIPTION
This replaces the deprecated method of calling `hass.config_entries.async_forward_entry_setup`.

See this HA developer [blog post](https://developers.home-assistant.io/blog/2024/06/12/async_forward_entry_setups/) on the issue:

> Calling `hass.config_entries.async_forward_entry_setup` is deprecated and will be removed in Home Assistant 2025.6. Instead, await `hass.config_entries.async_forward_entry_setups` as it can load multiple platforms at once and is more efficient since it does not require a separate import executor job for each platform.

