### PR TITLE
Avoid blocking operations in event loop

### DIFF
--- a/custom_components/ical/__init__.py
+++ b/custom_components/ical/__init__.py
@@ -32,7 +32,7 @@ PLATFORMS = ["sensor", "calendar"]
 MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=120)
 
 
-def setup(hass, config):
+def setup(hass: HomeAssistant, config):
     """Set up this integration with config flow."""
     return True
 
@@ -75,7 +75,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
 class ICalEvents:
     """Get a list of events."""
 
-    def __init__(self, hass, config):
+    def __init__(self, hass: HomeAssistant, config):
         """Set up a calendar object."""
         self.hass = hass
         self.name = config.get(CONF_NAME)
@@ -87,7 +87,7 @@ class ICalEvents:
         self.event = None
         self.all_day = False
 
-    async def async_get_events(self, hass, start_date, end_date):
+    async def async_get_events(self, hass: HomeAssistant, start_date, end_date):
         """Get list of upcoming events."""
         _LOGGER.debug("Running ICalEvents async_get_events")
         events = []

--- a/custom_components/ical/__init__.py
+++ b/custom_components/ical/__init__.py
@@ -9,13 +9,13 @@ from dateutil.rrule import rruleset, rrulestr
 from dateutil.tz import gettz, tzutc
 import icalendar
 import voluptuous as vol
-from homeassistant.components.calendar import CalendarEvent
 
+from homeassistant.components.calendar import CalendarEvent
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_NAME, CONF_URL, CONF_VERIFY_SSL
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
-from homeassistant.util import Throttle, dt
+from homeassistant.util import Throttle, dt as dt_util
 
 from .const import CONF_DAYS, CONF_MAX_EVENTS, DOMAIN
 
@@ -106,7 +106,13 @@ class ICalEvents:
                     _LOGGER.debug("... and it has")
                     # strongly type class fix
                     events.append(
-                        CalendarEvent(event["start"], event["end"], event["summary"], event["description"], event["location"])
+                        CalendarEvent(
+                            event["start"],
+                            event["end"],
+                            event["summary"],
+                            event["description"],
+                            event["location"],
+                        )
                     )
                     # events.append(event)
         return events
@@ -130,17 +136,17 @@ class ICalEvents:
             # Some calendars are for some reason filled with NULL-bytes.
             # They break the parsing, so we get rid of them
             event_list = icalendar.Calendar.from_ical(text.replace("\x00", ""))
-            start_of_events = dt.start_of_local_day()
-            end_of_events = dt.start_of_local_day() + timedelta(days=self.days)
+            start_of_events = dt_util.start_of_local_day()
+            end_of_events = dt_util.start_of_local_day() + timedelta(days=self.days)
 
-            self.calendar = self._ical_parser(
+            self.calendar = await self._ical_parser(
                 event_list, start_of_events, end_of_events
             )
 
         if len(self.calendar) > 0:
             found_next_event = False
             for event in self.calendar:
-                if event["end"] > dt.now() and not found_next_event:
+                if event["end"] > dt_util.now() and not found_next_event:
                     _LOGGER.debug(
                         "Event %s it the first event with end in the future: %s",
                         event["summary"],
@@ -149,7 +155,7 @@ class ICalEvents:
                     self.event = event
                     found_next_event = True
 
-    def _ical_parser(self, calendar, from_date, to_date):
+    async def _ical_parser(self, calendar, from_date, to_date):
         """Return a sorted list of events from a icalendar object."""
 
         events = []
@@ -178,30 +184,34 @@ class ICalEvents:
                     _LOGGER.debug("UNTIL in rrule: %s", str(rrule["UNTIL"]))
                     # Ensure that UNTIL is tz-aware and in UTC
                     # (Not all icalendar implements this correctly)
-                    until = self._ical_date_fixer(rrule["UNTIL"], "UTC")
+                    until = await self._ical_date_fixer(rrule["UNTIL"], "UTC")
                     rrule["UNTIL"] = [until]
                 else:
                     _LOGGER.debug("No UNTIL in rrule")
 
                 _LOGGER.debug("DTSTART in rrule: %s", str(event["DTSTART"].dt))
-                dtstart = self._ical_date_fixer(
-                    event["DTSTART"].dt, dt.DEFAULT_TIME_ZONE
+                dtstart = await self._ical_date_fixer(
+                    event["DTSTART"].dt, dt_util.DEFAULT_TIME_ZONE
                 )
 
                 if "DTEND" not in event:
                     _LOGGER.debug("Event found without end datetime")
                     if self.all_day:
                         # if it's an all day event with no endtime listed, we'll assume it ends at 23:59:59
-                        _LOGGER.debug(f"Event {event['SUMMARY']} is flagged as all day, with a start time of {start}.")
+                        _LOGGER.debug(
+                            f"Event {event['SUMMARY']} is flagged as all day, with a start time of {dtstart}."
+                        )
                         dtend = dtstart + timedelta(days=1, seconds=-1)
                         _LOGGER.debug(f"Setting the end time to {dtend}")
                     else:
-                        _LOGGER.debug(f"Event {event['SUMMARY']} doesn't have an end but isn't flagged as all day.")
+                        _LOGGER.debug(
+                            f"Event {event['SUMMARY']} doesn't have an end but isn't flagged as all day."
+                        )
                         dtend = dtstart
                 else:
                     _LOGGER.debug("DTEND in event")
-                    dtend = self._ical_date_fixer(
-                        event["DTEND"].dt, dt.DEFAULT_TIME_ZONE
+                    dtend = await self._ical_date_fixer(
+                        event["DTEND"].dt, dt_util.DEFAULT_TIME_ZONE
                     )
 
                 # So hopefully we now have a proper dtstart we can use to create the start-times according to the rrule
@@ -326,8 +336,8 @@ class ICalEvents:
                     pass
 
                 _LOGGER.debug("DTSTART in event: {}".format(event["DTSTART"].dt))
-                dtstart = self._ical_date_fixer(
-                    event["DTSTART"].dt, dt.DEFAULT_TIME_ZONE
+                dtstart = await self._ical_date_fixer(
+                    event["DTSTART"].dt, dt_util.DEFAULT_TIME_ZONE
                 )
 
                 start = dtstart
@@ -336,16 +346,20 @@ class ICalEvents:
                     _LOGGER.debug("Event found without end datetime")
                     if self.all_day:
                         # if it's an all day event with no endtime listed, we'll assume it ends at 23:59:59
-                        _LOGGER.debug(f"Event {event['SUMMARY']} is flagged as all day, with a start time of {start}.")
+                        _LOGGER.debug(
+                            f"Event {event['SUMMARY']} is flagged as all day, with a start time of {start}."
+                        )
                         dtend = dtstart + timedelta(days=1, seconds=-1)
                         _LOGGER.debug(f"Setting the end time to {dtend}")
                     else:
-                        _LOGGER.debug(f"Event {event['SUMMARY']} doesn't have an end but isn't flagged as all day.")
+                        _LOGGER.debug(
+                            f"Event {event['SUMMARY']} doesn't have an end but isn't flagged as all day."
+                        )
                         dtend = dtstart
                 else:
                     _LOGGER.debug("DTEND in event")
-                    dtend = self._ical_date_fixer(
-                        event["DTEND"].dt, dt.DEFAULT_TIME_ZONE
+                    dtend = await self._ical_date_fixer(
+                        event["DTEND"].dt, dt_util.DEFAULT_TIME_ZONE
                     )
                 end = dtend
 
@@ -353,8 +367,7 @@ class ICalEvents:
                 if event_dict:
                     events.append(event_dict)
 
-        sorted_events = sorted(events, key=lambda k: k["start"])
-        return sorted_events
+        return sorted(events, key=lambda k: k["start"])
 
     def _ical_event_dict(self, start, end, from_date, event):
         """Ensure that events are within the start and end."""
@@ -376,13 +389,13 @@ class ICalEvents:
             "Start: %s Tzinfo: %s Default: %s StartAs %s",
             str(start),
             str(start.tzinfo),
-            dt.DEFAULT_TIME_ZONE,
-            start.astimezone(dt.DEFAULT_TIME_ZONE),
+            dt_util.DEFAULT_TIME_ZONE,
+            start.astimezone(dt_util.DEFAULT_TIME_ZONE),
         )
         event_dict = {
             "summary": event.get("SUMMARY", "Unknown"),
-            "start": start.astimezone(dt.DEFAULT_TIME_ZONE),
-            "end": end.astimezone(dt.DEFAULT_TIME_ZONE),
+            "start": start.astimezone(dt_util.DEFAULT_TIME_ZONE),
+            "end": end.astimezone(dt_util.DEFAULT_TIME_ZONE),
             "location": event.get("LOCATION"),
             "description": event.get("DESCRIPTION"),
             "all_day": self.all_day,
@@ -390,7 +403,7 @@ class ICalEvents:
         _LOGGER.debug("Event to add: %s", str(event_dict))
         return event_dict
 
-    def _ical_date_fixer(self, indate, timezone="UTC"):
+    async def _ical_date_fixer(self, indate, timezone="UTC"):
         """Convert something that looks kind of like a date or datetime to a timezone-aware datetime-object."""
         self.all_day = False
 
@@ -404,24 +417,34 @@ class ICalEvents:
         if not isinstance(indate, datetime):
             try:
                 self.all_day = True
-                indate = datetime(indate.year, indate.month, indate.day, 0, 0, 0)
+                indate = await self.hass.async_add_executor_job(
+                    datetime, indate.year, indate.month, indate.day, 0, 0, 0
+                )
             except Exception as e:
                 _LOGGER.error("Unable to parse indate: %s", str(e))
+
+        indate_replaced = await self.hass.async_add_executor_job(
+            self._date_replace, indate, timezone
+        )
+
+        _LOGGER.debug("Out date: %s", str(indate_replaced))
+        return indate_replaced
+
+    def _date_replace(self, indate: datetime, timezone):
+        """Replace tzinfo in a datetime object."""
 
         # Indate can be TZ naive
         if indate.tzinfo is None or indate.tzinfo.utcoffset(indate) is None:
             # _LOGGER.debug("TZ-Naive indate: %s Adding TZ %s", str(indate), str(gettz(str(timezone))))
             # tz = pytz.timezone(str(timezone))
             # indate = tz.localize(indate)
-            indate = indate.replace(tzinfo=gettz(str(timezone)))
-        # Rrules dont play well with pytz
+            return indate.replace(tzinfo=gettz(str(timezone)))
+        # Rules dont play well with pytz
         # _LOGGER.debug("Tzinfo 1: %s", str(indate.tzinfo))
         if not str(indate.tzinfo).startswith("tzfile"):
             # _LOGGER.debug("Pytz indate: %s. replacing with tz %s", str(indate), str(gettz(str(indate.tzinfo))))
-            indate = indate.replace(tzinfo=gettz(str(indate.tzinfo)))
+            return indate.replace(tzinfo=gettz(str(indate.tzinfo)))
         if str(indate.tzinfo).endswith("/UTC"):
-            indate = indate.replace(tzinfo=tzutc)
+            return indate.replace(tzinfo=tzutc)
         # _LOGGER.debug("Tzinfo 2: %s", str(indate.tzinfo))
-
-        _LOGGER.debug("Out date: %s", str(indate))
-        return indate
+        return None


### PR DESCRIPTION
According to https://developers.home-assistant.io/docs/asyncio_blocking_operations/ we should not use blocking calls in the event loop, which is also indicated as  a warning at HA startup:

Logger: homeassistant.util.loop
Quelle: util/loop.py:136
Erstmals aufgetreten: 08:53:23 (1 Vorkommnisse)
Zuletzt protokolliert: 08:53:23

`Detected blocking call to open with args ('/usr/share/zoneinfo/UTC', 'rb') inside the event loop by custom integration 'ical' at custom_components/ical/__init__.py, line 888: indate = indate.replace(tzinfo=gettz(str(indate.tzinfo))) (offender: /home/vscode/.local/ha-venv/lib/python3.12/site-packages/dateutil/tz/tz.py, line 464: fileobj = open(fileobj, 'rb')), please create a bug report at https://github.com/tybritten/ical-sensor-homeassistant/issues For developers, please see https://developers.home-assistant.io/docs/asyncio_blocking_operations/#open Traceback (most recent call last): File "/usr/local/lib/python3.12/runpy.py", line 198, in _run_module_as_main return _run_code(code, main_globals, None, File "/usr/local/lib/python3.12/runpy.py", line 88, in _run_code exec(code, run_globals) File "/home/vscode/.vscode-server/extensions/ms-python.debugpy-2024.10.0-linux-arm64/bundled/libs/debugpy/adapter/../../debugpy/launcher/../../debugpy/__main__.py", line 39, in <module> cli.main() File "/home/vscode/.vscode-server/extensions/ms-python.debugpy-2024.10.0-linux-arm64/bundled/libs/debugpy/adapter/../../debugpy/launcher/../../debugpy/../debugpy/server/cli.py", line 430, in main run() File "/home/vscode/.vscode-server/extensions/ms-python.debugpy-2024.10.0-linux-arm64/bundled/libs/debugpy/adapter/../../debugpy/launcher/../../debugpy/../debugpy/server/cli.py", line 317, in run_module run_module_as_main(options.target, alter_argv=True) File "/home/vscode/.vscode-server/extensions/ms-python.debugpy-2024.10.0-linux-arm64/bundled/libs/debugpy/_vendored/pydevd/_pydevd_bundle/pydevd_runpy.py", line 238, in _run_module_as_main return _run_code(code, main_globals, None, File "/home/vscode/.vscode-server/extensions/ms-python.debugpy-2024.10.0-linux-arm64/bundled/libs/debugpy/_vendored/pydevd/_pydevd_bundle/pydevd_runpy.py", line 124, in _run_code exec(code, run_globals) File "/workspaces/core/homeassistant/__main__.py", line 223, in <module> sys.exit(main()) File "/workspaces/core/homeassistant/__main__.py", line 209, in main exit_code = runner.run(runtime_conf) File "/workspaces/core/homeassistant/runner.py", line 189, in run return loop.run_until_complete(setup_and_run_hass(runtime_config)) File "/usr/local/lib/python3.12/asyncio/base_events.py", line 674, in run_until_complete self.run_forever() File "/usr/local/lib/python3.12/asyncio/base_events.py", line 641, in run_forever self._run_once() File "/usr/local/lib/python3.12/asyncio/base_events.py", line 1978, in _run_once handle._run() File "/usr/local/lib/python3.12/asyncio/events.py", line 88, in _run self._context.run(self._callback, *self._args) File "/workspaces/core/config/custom_components/ical/sensor.py", line 33, in async_setup_entry await ical_events.update() File "/workspaces/core/config/custom_components/ical/__init__.py", line 595, in update self.calendar = self._ical_parser( File "/workspaces/core/config/custom_components/ical/__init__.py", line 792, in _ical_parser dtstart = self._ical_date_fixer( File "/workspaces/core/config/custom_components/ical/__init__.py", line 888, in _ical_date_fixer indate = indate.replace(tzinfo=gettz(str(indate.tzinfo)))`

This PR fixes this this blocking call. I also refactored some code pieces to get rid of some lifting warnings...