### PR TITLE
Replace manual RRULE handling with recurring-ical-events

### DIFF
--- a/custom_components/ical/__init__.py
+++ b/custom_components/ical/__init__.py
@@ -1,13 +1,12 @@
 """The ical integration."""
 
 import asyncio
-from datetime import datetime, timedelta
+from datetime import date, datetime, timedelta
 import logging
 from urllib.parse import urlparse
 
-from dateutil.rrule import rruleset, rrulestr
-from dateutil.tz import gettz, tzutc
 import icalendar
+import recurring_ical_events
 import voluptuous as vol
 
 from homeassistant.components.calendar import CalendarEvent
@@ -27,6 +26,11 @@ CONFIG_SCHEMA = vol.Schema({DOMAIN: vol.Schema({})}, extra=vol.ALLOW_EXTRA)
 PLATFORMS = ["sensor", "calendar"]
 
 MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=120)
+
+
+def check_event(d: datetime, all_day: bool) -> datetime | date:
+    """Return date object for all-day events, datetime otherwise."""
+    return d.date() if all_day else d
 
 
 def setup(hass: HomeAssistant, config):
@@ -87,8 +91,8 @@ class ICalEvents:
                 if event["start"] < end_date and event["end"] > start_date:
                     events.append(
                         CalendarEvent(
-                            event["start"],
-                            event["end"],
+                            check_event(event["start"], event["all_day"]),
+                            check_event(event["end"], event["all_day"]),
                             event["summary"],
                             event["description"],
                             event["location"],
@@ -131,327 +135,64 @@ class ICalEvents:
 
     async def _ical_parser(self, calendar, from_date, to_date):
         """Return a sorted list of events from a icalendar object."""
-
         events = []
 
-        for event in calendar.walk("VEVENT"):
-            # RRULEs turns out to be harder than initially thought.
-            # This is mainly due to pythons handling of TZ-naive and TZ-aware timestamps, and the inconsistensies
-            # in the way RRULEs are implemented in the icalendar library.
-            if "RRULE" in event:
-                if "SUMMARY" not in event:
-                    _LOGGER.debug("Event without SUMMARY key: %s", str(event))
-                _LOGGER.debug("RRULE in event: %s", str(event.get("SUMMARY", "Unknown")))
-                rrule = event["RRULE"]
-                start_rules = rruleset()
-                end_rules = rruleset()
+        recurring_events = await self.hass.async_add_executor_job(
+            lambda: recurring_ical_events.of(calendar, skip_bad_series=True).between(
+                from_date, to_date
+            )
+        )
 
-                if "UNTIL" in rrule:
-                    try:
-                        # Just ignore events that ended a long time ago
-                        if rrule["UNTIL"][0] < from_date - timedelta(days=30):
-                            _LOGGER.debug(
-                                "Old event 1 %s - ended %s",
-                                event.get("SUMMARY", "Unknown"),
-                                str(rrule["UNTIL"][0]),
-                            )
-                            continue
-                    except Exception:
-                        pass
+        for event in recurring_events:
+            dtstart = event["DTSTART"].dt
+            dtend = event["DTEND"].dt if "DTEND" in event else dtstart
 
-                    _LOGGER.debug("UNTIL in rrule: %s", str(rrule["UNTIL"]))
-                    # Ensure that UNTIL is tz-aware and in UTC
-                    # (Not all icalendar implements this correctly)
-                    until = await self._ical_date_fixer(rrule["UNTIL"], "UTC")
-                    rrule["UNTIL"] = [until]
-                else:
-                    _LOGGER.debug("No UNTIL in rrule")
+            # Detect all-day events (date objects, not datetime)
+            self.all_day = isinstance(dtstart, date) and not isinstance(
+                dtstart, datetime
+            )
 
-                _LOGGER.debug("DTSTART in rrule: %s", str(event["DTSTART"].dt))
-                dtstart = await self._ical_date_fixer(
-                    event["DTSTART"].dt, dt_util.DEFAULT_TIME_ZONE
+            # Convert date to datetime for consistent handling
+            if not isinstance(dtstart, datetime):
+                dtstart = datetime(
+                    dtstart.year,
+                    dtstart.month,
+                    dtstart.day,
+                    tzinfo=dt_util.DEFAULT_TIME_ZONE,
+                )
+            if not isinstance(dtend, datetime):
+                dtend = datetime(
+                    dtend.year,
+                    dtend.month,
+                    dtend.day,
+                    tzinfo=dt_util.DEFAULT_TIME_ZONE,
                 )
 
-                if "DTEND" not in event:
-                    _LOGGER.debug("Event found without end datetime")
-                    if self.all_day:
-                        # if it's an all day event with no endtime listed, we'll assume it ends at 23:59:59
-                        _LOGGER.debug(
-                            f"Event {event['SUMMARY']} is flagged as all day, with a start time of {dtstart}."
-                        )
-                        dtend = dtstart + timedelta(days=1, seconds=-1)
-                        _LOGGER.debug(f"Setting the end time to {dtend}")
-                    else:
-                        _LOGGER.debug(
-                            f"Event {event['SUMMARY']} doesn't have an end but isn't flagged as all day."
-                        )
-                        dtend = dtstart
-                else:
-                    _LOGGER.debug("DTEND in event")
-                    dtend = await self._ical_date_fixer(
-                        event["DTEND"].dt, dt_util.DEFAULT_TIME_ZONE
-                    )
+            # Ensure timezone awareness
+            if dtstart.tzinfo is None:
+                dtstart = dtstart.replace(tzinfo=dt_util.DEFAULT_TIME_ZONE)
+            if dtend.tzinfo is None:
+                dtend = dtend.replace(tzinfo=dt_util.DEFAULT_TIME_ZONE)
 
-                try:
-                    rrule_obj = rrulestr(
-                        rrule.to_ical().decode("utf-8"), dtstart=dtstart
-                    )
-                    start_rules.rrule(rrule_obj)
-                except ValueError as e:
-                    # Handle specific ValueError like "year 10000 is out of range"
-                    if "year" in str(e) and "out of range" in str(e):
-                        _LOGGER.warning(
-                            "RRule for event '%s' contains dates out of range. Skipping. Error: %s",
-                            str(event.get("SUMMARY", "Unknown")),
-                            str(e),
-                        )
-                        continue
-                    else:
-                        # If this fails, move on to the next event
-                        _LOGGER.error(
-                            "ValueError in start_rules.rrule: %s - Start: %s - RRule: %s",
-                            str(e),
-                            str(event.get("SUMMARY", "Unknown")),
-                            str(dtstart),
-                            str(event["RRULE"]),
-                        )
-                        continue
-                except Exception as e:
-                    # If this fails, move on to the next event
-                    _LOGGER.error(
-                        "Exception %s in start_rules.rrule: %s - Start: %s - RRule: %s",
-                        str(e),
-                        str(event.get("SUMMARY", "Unknown")),
-                        str(dtstart),
-                        str(event["RRULE"]),
-                    )
-                    continue
-
-                try:
-                    rrule_obj = rrulestr(rrule.to_ical().decode("utf-8"), dtstart=dtend)
-                    end_rules.rrule(rrule_obj)
-                except ValueError as e:
-                    # Handle specific ValueError like "year 10000 is out of range"
-                    if "year" in str(e) and "out of range" in str(e):
-                        _LOGGER.warning(
-                            "RRule for event '%s' contains end dates out of range. Using start rules. Error: %s",
-                            str(event.get("SUMMARY", "Unknown")),
-                            str(e),
-                        )
-                        end_rules = start_rules
-                    else:
-                        # If this fails, just use the start-rules
-                        _LOGGER.error(
-                            "ValueError in end_rules.rrule: %s - End: %s - RRule: %s",
-                            str(e),
-                            str(event.get("SUMMARY", "Unknown")),
-                            str(dtend),
-                            str(event["RRULE"]),
-                        )
-                        end_rules = start_rules
-                except Exception as e:
-                    # If this fails, just use the start-rules
-                    _LOGGER.error(
-                        "Exception %s in end_rules.rrule: %s - End: %s - RRule: %s",
-                        str(e),
-                        str(event.get("SUMMARY", "Unknown")),
-                        str(dtend),
-                        str(event["RRULE"]),
-                    )
-                    end_rules = start_rules
-                
-                # Only process EXDATEs if we have any
-                if "EXDATE" in event:
-                    try:
-                        if isinstance(event["EXDATE"], list):
-                            for exdate in event["EXDATE"]:
-                                for edate in exdate.dts:
-                                    exdate_dt = edate.dt
-                                    if not isinstance(exdate_dt, datetime):
-                                        exdate_dt = await self._ical_date_fixer(
-                                            exdate_dt, "UTC"
-                                        )
-                                    start_rules.exdate(exdate_dt)
-                                    end_rules.exdate(exdate_dt)
-                        else:
-                            for edate in event["EXDATE"].dts:
-                                exdate_dt = edate.dt
-                                if not isinstance(exdate_dt, datetime):
-                                    exdate_dt = await self._ical_date_fixer(
-                                        exdate_dt, "UTC"
-                                    )
-                                start_rules.exdate(exdate_dt)
-                                end_rules.exdate(exdate_dt)
-                    except Exception as e:
-                        _LOGGER.error(
-                            "Exception %s in EXDATE: %s - Start: %s - RRule: %s - EXDate: %s",
-                            str(e),
-                            str(event.get("SUMMARY", "Unknown")),
-                            str(dtstart),
-                            str(event["RRULE"]),
-                            str(event["EXDATE"]),
-                        )
-                        continue
-
-                try:
-                    # Convert dates to datetime if needed and ensure timezone awareness
-                    after_date = from_date - timedelta(days=7)
-                    
-                    if not isinstance(after_date, datetime):
-                        after_date = datetime.combine(after_date, datetime.min.time())
-                    if not isinstance(to_date, datetime):
-                        to_date = datetime.combine(to_date, datetime.max.time())
-
-                    # Ensure both dates are timezone-aware
-                    if after_date.tzinfo is None:
-                        after_date = after_date.replace(
-                            tzinfo=dt_util.DEFAULT_TIME_ZONE
-                        )
-                    if to_date.tzinfo is None:
-                        to_date = to_date.replace(tzinfo=dt_util.DEFAULT_TIME_ZONE)
-
-                    # Additional check to ensure consistent datetime types
-                    # This is to prevent comparison errors between date and datetime objects
-                    if hasattr(after_date, "date") and not isinstance(
-                        after_date, datetime
-                    ):
-                        after_date = datetime.combine(after_date, datetime.min.time())
-                    if hasattr(to_date, "date") and not isinstance(to_date, datetime):
-                        to_date = datetime.combine(to_date, datetime.max.time())
-
-                    # Ensure timezone awareness for both dates
-                    if hasattr(after_date, "tzinfo") and after_date.tzinfo is None:
-                        after_date = after_date.replace(
-                            tzinfo=dt_util.DEFAULT_TIME_ZONE
-                        )
-                    if hasattr(to_date, "tzinfo") and to_date.tzinfo is None:
-                        to_date = to_date.replace(tzinfo=dt_util.DEFAULT_TIME_ZONE)
-
-
-
-                    # Ensure consistent datetime types for comparison
-                    # The issue is that rruleset.between can return date objects even when we're working with datetime objects
-                    starts = start_rules.between(after=after_date, before=to_date)
-                    ends = end_rules.between(after=after_date, before=to_date)
-                except ValueError as e:
-                    # Handle specific ValueError like "year 10000 is out of range"
-                    if "year" in str(e) and "out of range" in str(e):
-                        _LOGGER.warning(
-                            "RRule date range for event '%s' is out of range. Skipping. Error: %s",
-                            str(event.get("SUMMARY", "Unknown")),
-                            str(e),
-                        )
-                        continue
-                    else:
-                        # Add more detailed logging to troubleshoot the datetime comparison error
-                        _LOGGER.error(
-                            "ValueError in starts/ends: %s - Start: %s - End: %s, RRule: %s",
-                            str(e),
-                            str(event.get("SUMMARY", "Unknown")),
-                            str(dtstart),
-                            str(dtend),
-                            str(event["RRULE"]),
-                        )
-                        continue
-                except Exception as e:
-                    # Add more detailed logging to troubleshoot the datetime comparison error
-                    _LOGGER.error(
-                        "Exception %s in starts/ends: %s - Start: %s - End: %s, RRule: %s",
-                        str(e),
-                        str(event.get("SUMMARY", "Unknown")),
-                        str(dtstart),
-                        str(dtend),
-                        str(event["RRULE"]),
-                    )
-                    continue
-
-                if len(starts) < 1:
-                    continue
-
-                ends.reverse()
-                for start in starts:
-                    if len(ends) == 0:
-                        continue
-                    end = ends.pop()
-                    event_dict = self._ical_event_dict(start, end, from_date, event)
-
-                    if event_dict:
-                        events.append(event_dict)
-
-
-            else:
-                try:
-                    # Just ignore events that ended a long time ago
-                    if "DTEND" in event and event[
-                        "DTEND"
-                    ].dt.date() < from_date.date() - timedelta(days=30):
-                        # Only log if we're at debug level to avoid performance impact
-                        if _LOGGER.isEnabledFor(logging.DEBUG):
-                            _LOGGER.debug(
-                                "Old event 1 %s - ended %s",
-                                event.get("SUMMARY", "Unknown"),
-                                str(event["DTEND"].dt),
-                            )
-                        continue
-                except Exception as e:
-                    if _LOGGER.isEnabledFor(logging.DEBUG):
-                        _LOGGER.debug("1: %s", str(e))
-                    pass
-                try:
-                    if "DTEND" in event and event[
-                        "DTEND"
-                    ].dt < from_date.date() - timedelta(days=30):
-                        # Only log if we're at debug level to avoid performance impact
-                        if _LOGGER.isEnabledFor(logging.DEBUG):
-                            _LOGGER.debug(
-                                "Old event 2 %s - ended %s",
-                                event.get("SUMMARY", "Unknown"),
-                                str(event["DTEND"].dt),
-                            )
-                        continue
-                except Exception as e:
-                    if _LOGGER.isEnabledFor(logging.DEBUG):
-                        _LOGGER.debug("2: %s", str(e))
-                    pass
-
-                # Only log if we're at debug level to avoid performance impact
-                if _LOGGER.isEnabledFor(logging.DEBUG):
-                    _LOGGER.debug("DTSTART in event: {}".format(event["DTSTART"].dt))
-                dtstart = await self._ical_date_fixer(
-                    event["DTSTART"].dt, dt_util.DEFAULT_TIME_ZONE
-                )
-
-                start = dtstart
-
-                if "DTEND" not in event:
-                    _LOGGER.debug("Event found without end datetime")
-                    if self.all_day:
-                        # if it's an all day event with no endtime listed, we'll assume it ends at 23:59:59
-                        _LOGGER.debug(
-                            f"Event {event['SUMMARY']} is flagged as all day, with a start time of {start}."
-                        )
-                        dtend = dtstart + timedelta(days=1, seconds=-1)
-                        _LOGGER.debug(f"Setting the end time to {dtend}")
-                    else:
-                        _LOGGER.debug(
-                            f"Event {event['SUMMARY']} doesn't have an end but isn't flagged as all day."
-                        )
-                        dtend = dtstart
-                else:
-                    _LOGGER.debug("DTEND in event")
-                    dtend = await self._ical_date_fixer(
-                        event["DTEND"].dt, dt_util.DEFAULT_TIME_ZONE
-                    )
-                end = dtend
-
-                event_dict = self._ical_event_dict(start, end, from_date, event)
-                if event_dict:
-                    events.append(event_dict)
+            event_dict = self._ical_event_dict(dtstart, dtend, from_date, event)
+            if event_dict:
+                events.append(event_dict)
 
         return sorted(events, key=lambda k: k["start"])
 
     def _ical_event_dict(self, start, end, from_date, event):
         """Ensure that events are within the start and end."""
+
+        # Skip events where end is before start (can happen with
+        # overnight events after timezone conversion, see issue #160)
+        if end < start:
+            _LOGGER.warning(
+                "Skipping event '%s': end (%s) is before start (%s)",
+                event.get("SUMMARY", "Unknown"),
+                end,
+                start,
+            )
+            return None
 
         # Skip this event if it's in the past
         if end.date() < from_date.date():
@@ -491,69 +232,3 @@ class ICalEvents:
         if _LOGGER.isEnabledFor(logging.DEBUG):
             _LOGGER.debug("Event to add: %s", str(event_dict))
         return event_dict
-
-    async def _ical_date_fixer(self, indate, timezone="UTC"):
-        """Convert something that looks kind of like a date or datetime to a timezone-aware datetime-object."""
-        self.all_day = False
-
-        # Only log if we're at debug level to avoid performance impact
-        if _LOGGER.isEnabledFor(logging.DEBUG):
-            _LOGGER.debug("Fixing date: %s in TZ %s", str(indate), str(timezone))
-
-        # Indate can be a single entry or a list with one item...
-        if isinstance(indate, list):
-            indate = indate[0]
-
-        # Indate can be a date without time...
-        if not isinstance(indate, datetime):
-            try:
-                self.all_day = True
-                indate = await self.hass.async_add_executor_job(
-                    datetime, indate.year, indate.month, indate.day, 0, 0, 0
-                )
-            except Exception as e:
-                _LOGGER.error("Unable to parse indate: %s", str(e))
-
-        indate_replaced = await self.hass.async_add_executor_job(
-            self._date_replace, indate, timezone
-        )
-
-        # Only log if we're at debug level to avoid performance impact
-        if _LOGGER.isEnabledFor(logging.DEBUG):
-            _LOGGER.debug("Out date: %s", str(indate_replaced))
-        return indate_replaced
-
-    def _date_replace(self, indate: datetime, timezone):
-        """Replace tzinfo in a datetime object."""
-
-        # Indate can be TZ naive
-        if indate.tzinfo is None or indate.tzinfo.utcoffset(indate) is None:
-            # Only log if we're at debug level to avoid performance impact
-            if _LOGGER.isEnabledFor(logging.DEBUG):
-                _LOGGER.debug(
-                    "TZ-Naive indate: %s Adding TZ %s",
-                    str(indate),
-                    str(gettz(str(timezone))),
-                )
-            # tz = pytz.timezone(str(timezone))
-            # indate = tz.localize(indate)
-            return indate.replace(tzinfo=gettz(str(timezone)))
-        # Rules dont play well with pytz
-        # Only log if we're at debug level to avoid performance impact
-        if _LOGGER.isEnabledFor(logging.DEBUG):
-            _LOGGER.debug("Tzinfo 1: %s", str(indate.tzinfo))
-        if not str(indate.tzinfo).startswith("tzfile"):
-            # Only log if we're at debug level to avoid performance impact
-            if _LOGGER.isEnabledFor(logging.DEBUG):
-                _LOGGER.debug(
-                    "Pytz indate: %s. replacing with tz %s",
-                    str(indate),
-                    str(gettz(str(indate.tzinfo))),
-                )
-            return indate.replace(tzinfo=gettz(str(indate.tzinfo)))
-        if str(indate.tzinfo).endswith("/UTC"):
-            return indate.replace(tzinfo=tzutc)
-        # Only log if we're at debug level to avoid performance impact
-        if _LOGGER.isEnabledFor(logging.DEBUG):
-            _LOGGER.debug("Tzinfo 2: %s", str(indate.tzinfo))
-        return None

--- a/custom_components/ical/manifest.json
+++ b/custom_components/ical/manifest.json
@@ -12,9 +12,10 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/tybritten/ical-sensor-homeassistant/issues",
   "requirements": [
-    "icalendar==5.0.7"
+    "icalendar>=6.1.0,<7.0.0",
+    "recurring-ical-events>=3.8.0"
   ],
   "ssdp": [],
-  "version": "1.8.1",
+  "version": "1.9.0",
   "zeroconf": []
 }

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -3,4 +3,5 @@ pytest>=6.0
 pytest-asyncio
 pytest-cov
 homeassistant
-icalendar==5.0.7
+icalendar>=6.1.0,<7.0.0
+recurring-ical-events>=3.8.0

--- a/tests/test_calendar.py
+++ b/tests/test_calendar.py
@@ -1,11 +1,12 @@
 """Tests for the calendar platform."""
-from datetime import datetime, timezone
+
+from datetime import date, datetime, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from homeassistant.components.calendar import CalendarEvent
 from pathlib import Path
 
-from custom_components.ical.calendar import ICalCalendarEventDevice
+from custom_components.ical.calendar import ICalCalendarEventDevice, check_event
 
 
 @pytest.fixture
@@ -24,7 +25,7 @@ def mock_ical_events():
         "end": datetime(2023, 1, 1, 13, 0, 0, tzinfo=timezone.utc),
         "location": "Test Location",
         "description": "Test Description",
-        "all_day": False
+        "all_day": False,
     }
     ical_events.async_get_events = AsyncMock(return_value=[])
     ical_events.update = AsyncMock()
@@ -37,9 +38,9 @@ def test_calendar_device_init(mock_hass, mock_ical_events):
         hass=mock_hass,
         name="test_calendar",
         entity_id="calendar.test_calendar",
-        ical_events=mock_ical_events
+        ical_events=mock_ical_events,
     )
-    
+
     assert device.entity_id == "calendar.test_calendar"
     assert device._name == "test_calendar"
     assert device.ical_events == mock_ical_events
@@ -53,9 +54,9 @@ def test_calendar_device_name(mock_hass, mock_ical_events):
         hass=mock_hass,
         name="test_calendar",
         entity_id="calendar.test_calendar",
-        ical_events=mock_ical_events
+        ical_events=mock_ical_events,
     )
-    
+
     assert device.name == "test_calendar"
 
 
@@ -65,20 +66,20 @@ def test_calendar_device_event(mock_hass, mock_ical_events):
         hass=mock_hass,
         name="test_calendar",
         entity_id="calendar.test_calendar",
-        ical_events=mock_ical_events
+        ical_events=mock_ical_events,
     )
-    
+
     # Initially should be None
     assert device.event is None
-    
+
     # Set an event and test
     test_event = CalendarEvent(
         start=datetime(2023, 1, 1, 12, 0, 0, tzinfo=timezone.utc),
         end=datetime(2023, 1, 1, 13, 0, 0, tzinfo=timezone.utc),
-        summary="Test Event"
+        summary="Test Event",
     )
     device._event = test_event
-    
+
     assert device.event == test_event
 
 
@@ -88,14 +89,14 @@ def test_calendar_device_extra_state_attributes(mock_hass, mock_ical_events):
         hass=mock_hass,
         name="test_calendar",
         entity_id="calendar.test_calendar",
-        ical_events=mock_ical_events
+        ical_events=mock_ical_events,
     )
-    
+
     # Test with offset not reached
     device._offset_reached = False
     attrs = device.extra_state_attributes
     assert attrs["offset_reached"] is False
-    
+
     # Test with offset reached
     device._offset_reached = True
     attrs = device.extra_state_attributes
@@ -109,27 +110,29 @@ async def test_calendar_device_async_get_events(mock_hass, mock_ical_events):
         hass=mock_hass,
         name="test_calendar",
         entity_id="calendar.test_calendar",
-        ical_events=mock_ical_events
+        ical_events=mock_ical_events,
     )
-    
+
     start_date = datetime(2023, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
     end_date = datetime(2023, 1, 2, 0, 0, 0, tzinfo=timezone.utc)
-    
+
     # Mock the ical_events.async_get_events to return test events
     test_events = [
         CalendarEvent(
             start=datetime(2023, 1, 1, 12, 0, 0, tzinfo=timezone.utc),
             end=datetime(2023, 1, 1, 13, 0, 0, tzinfo=timezone.utc),
-            summary="Test Event"
+            summary="Test Event",
         )
     ]
     mock_ical_events.async_get_events.return_value = test_events
-    
+
     events = await device.async_get_events(mock_hass, start_date, end_date)
-    
+
     assert len(events) == 1
     assert events[0].summary == "Test Event"
-    mock_ical_events.async_get_events.assert_called_once_with(mock_hass, start_date, end_date)
+    mock_ical_events.async_get_events.assert_called_once_with(
+        mock_hass, start_date, end_date
+    )
 
 
 @pytest.mark.asyncio
@@ -139,16 +142,16 @@ async def test_calendar_device_async_update(mock_hass, mock_ical_events):
         hass=mock_hass,
         name="test_calendar",
         entity_id="calendar.test_calendar",
-        ical_events=mock_ical_events
+        ical_events=mock_ical_events,
     )
-    
+
     # Mock the copy.deepcopy to return the same event
-    with patch('copy.deepcopy', side_effect=lambda x: x):
+    with patch("copy.deepcopy", side_effect=lambda x: x):
         await device.async_update()
-    
+
     # Verify that ical_events.update was called
     mock_ical_events.update.assert_called_once()
-    
+
     # Verify that the event was set
     assert device._event is not None
     assert device._event.summary == "Test Event"
@@ -161,19 +164,19 @@ async def test_calendar_device_async_update_with_no_event(mock_hass):
     ical_events = MagicMock()
     ical_events.event = None
     ical_events.update = AsyncMock()
-    
+
     device = ICalCalendarEventDevice(
         hass=mock_hass,
         name="test_calendar",
         entity_id="calendar.test_calendar",
-        ical_events=ical_events
+        ical_events=ical_events,
     )
-    
+
     await device.async_update()
-    
+
     # Verify that ical_events.update was called
     ical_events.update.assert_called_once()
-    
+
     # Verify that the event is None
     assert device._event is None
 
@@ -184,38 +187,127 @@ async def test_calendar_device_with_rrule_ics_file(mock_hass):
     # This test verifies that the datetime comparison error has been fixed
     # The error "'<' not supported between instances of 'datetime.date' and 'datetime.datetime'"
     # should no longer occur
-    
+
     # Get the path to the rrule.ics file
-    rrule_file_path = Path(__file__).parent / "fixtures" / "sample_calendars" / "rrule.ics"
-    
+    rrule_file_path = (
+        Path(__file__).parent / "fixtures" / "sample_calendars" / "rrule.ics"
+    )
+
     # Create config that points to the rrule.ics file
     config = {
         "name": "test_rrule_calendar",
         "url": f"file://{rrule_file_path}",
         "max_events": 5,
         "days": 30,
-        "verify_ssl": True
+        "verify_ssl": True,
     }
-    
+
     # Create ICalEvents instance with the config
     from custom_components.ical import ICalEvents
+
     ical_events = ICalEvents(hass=mock_hass, config=config)
-    
+
     # Mock the hass.async_add_executor_job to avoid actual file I/O in tests
-    mock_hass.async_add_executor_job = AsyncMock(side_effect=lambda func, *args, **kwargs: func(*args, **kwargs))
-    
+    mock_hass.async_add_executor_job = AsyncMock(
+        side_effect=lambda func, *args, **kwargs: func(*args, **kwargs)
+    )
+
     # Mock logging to capture error messages
-    with patch('custom_components.ical._LOGGER.error') as mock_error:
+    with patch("custom_components.ical._LOGGER.error") as mock_error:
         await ical_events.update()
-        
+
         # Check that the specific error was NOT logged (it should be fixed)
         error_logged = any(
-            "'<' not supported between instances of 'datetime.date' and 'datetime.datetime'" in str(call)
+            "'<' not supported between instances of 'datetime.date' and 'datetime.datetime'"
+            in str(call)
             for call in mock_error.call_args_list
         )
-        
+
         # Assert that the error was NOT logged (fix is working)
-        assert not error_logged, "The datetime comparison error should be fixed and not logged"
-        
+        assert (
+            not error_logged
+        ), "The datetime comparison error should be fixed and not logged"
+
         # Verify that events were processed successfully
         assert len(ical_events.calendar) > 0, "Events should be processed successfully"
+
+
+def test_check_event_datetime():
+    """Test check_event returns datetime for non-all-day events."""
+    dt = datetime(2023, 6, 15, 14, 30, 0, tzinfo=timezone.utc)
+    result = check_event(dt, all_day=False)
+    assert isinstance(result, datetime)
+    assert result == dt
+
+
+def test_check_event_all_day():
+    """Test check_event returns date for all-day events."""
+    dt = datetime(2023, 6, 15, 0, 0, 0, tzinfo=timezone.utc)
+    result = check_event(dt, all_day=True)
+    assert isinstance(result, date)
+    assert not isinstance(result, datetime)
+    assert result == date(2023, 6, 15)
+
+
+@pytest.mark.asyncio
+async def test_calendar_device_async_update_all_day(mock_hass):
+    """Test async_update passes date objects for all-day events."""
+    ical_events = MagicMock()
+    ical_events.event = {
+        "summary": "All Day Event",
+        "start": datetime(2023, 6, 15, 0, 0, 0, tzinfo=timezone.utc),
+        "end": datetime(2023, 6, 16, 0, 0, 0, tzinfo=timezone.utc),
+        "location": None,
+        "description": None,
+        "all_day": True,
+    }
+    ical_events.update = AsyncMock()
+
+    device = ICalCalendarEventDevice(
+        hass=mock_hass,
+        name="test_calendar",
+        entity_id="calendar.test_calendar",
+        ical_events=ical_events,
+    )
+
+    await device.async_update()
+
+    assert device._event is not None
+    # CalendarEvent start/end should be date objects, not datetime
+    assert isinstance(device._event.start, date)
+    assert not isinstance(device._event.start, datetime)
+    assert isinstance(device._event.end, date)
+    assert not isinstance(device._event.end, datetime)
+    assert device._event.start == date(2023, 6, 15)
+    assert device._event.end == date(2023, 6, 16)
+    assert device._event.summary == "All Day Event"
+
+
+@pytest.mark.asyncio
+async def test_calendar_device_async_update_timed_event(mock_hass):
+    """Test async_update keeps datetime objects for timed events."""
+    ical_events = MagicMock()
+    ical_events.event = {
+        "summary": "Timed Event",
+        "start": datetime(2023, 6, 15, 14, 0, 0, tzinfo=timezone.utc),
+        "end": datetime(2023, 6, 15, 15, 0, 0, tzinfo=timezone.utc),
+        "location": "Office",
+        "description": "A meeting",
+        "all_day": False,
+    }
+    ical_events.update = AsyncMock()
+
+    device = ICalCalendarEventDevice(
+        hass=mock_hass,
+        name="test_calendar",
+        entity_id="calendar.test_calendar",
+        ical_events=ical_events,
+    )
+
+    await device.async_update()
+
+    assert device._event is not None
+    # CalendarEvent start/end should remain datetime objects
+    assert isinstance(device._event.start, datetime)
+    assert isinstance(device._event.end, datetime)
+    assert device._event.summary == "Timed Event"

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,14 +1,10 @@
 """Tests for the ICalEvents class."""
-import asyncio
-from datetime import datetime, timezone, timedelta
+
+from datetime import date, datetime, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
-from icalendar import Calendar
-import pytz
 
-from custom_components.ical import ICalEvents
-from homeassistant.util import dt as dt_util
-from homeassistant.components.calendar import CalendarEvent
+from custom_components.ical import ICalEvents, check_event
 
 
 @pytest.fixture
@@ -27,14 +23,14 @@ def basic_config():
         "url": "file:///test/basic.ics",
         "max_events": 5,
         "days": 365,
-        "verify_ssl": True
+        "verify_ssl": True,
     }
 
 
 def test_ical_events_init(mock_hass, basic_config):
     """Test ICalEvents initialization."""
     ical_events = ICalEvents(hass=mock_hass, config=basic_config)
-    
+
     assert ical_events.hass == mock_hass
     assert ical_events.name == "test_calendar"
     assert ical_events.url == "file:///test/basic.ics"
@@ -44,46 +40,6 @@ def test_ical_events_init(mock_hass, basic_config):
     assert ical_events.calendar == []
     assert ical_events.event is None
     assert ical_events.all_day is False
-
-
-@pytest.mark.asyncio
-async def test_ical_date_fixer_with_datetime(mock_hass, basic_config):
-    """Test _ical_date_fixer with datetime object."""
-    ical_events = ICalEvents(hass=mock_hass, config=basic_config)
-    
-    # Mock the hass.async_add_executor_job to return the datetime as-is
-    mock_hass.async_add_executor_job = AsyncMock(side_effect=lambda f, *args: f(*args))
-    
-    test_date = datetime(2023, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
-    result = await ical_events._ical_date_fixer(test_date, "UTC")
-    
-    assert isinstance(result, datetime)
-    assert result.year == 2023
-    assert result.month == 1
-    assert result.day == 1
-    assert result.hour == 12
-
-
-@pytest.mark.asyncio
-async def test_ical_date_fixer_with_date(mock_hass, basic_config):
-    """Test _ical_date_fixer with date object."""
-    ical_events = ICalEvents(hass=mock_hass, config=basic_config)
-    
-    from datetime import date
-    test_date = date(2023, 1, 1)
-    
-    # Mock the hass.async_add_executor_job to return a datetime
-    mock_hass.async_add_executor_job = AsyncMock(
-        side_effect=lambda f, *args: datetime(2023, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
-    )
-    
-    result = await ical_events._ical_date_fixer(test_date, "UTC")
-    
-    assert isinstance(result, datetime)
-    assert result.year == 2023
-    assert result.month == 1
-    assert result.day == 1
-    assert ical_events.all_day is True
 
 
 @pytest.mark.asyncio
@@ -102,28 +58,32 @@ DESCRIPTION:This is a test event
 LOCATION:Test Location
 END:VEVENT
 END:VCALENDAR"""
-    
+
     ics_file = tmp_path / "test.ics"
     ics_file.write_text(ics_content)
-    
+
     # Update config to use the temporary file
     file_config = basic_config.copy()
     file_config["url"] = f"file://{ics_file}"
-    
+
     ical_events = ICalEvents(hass=mock_hass, config=file_config)
-    
+
     # Mock the _ical_parser to return a simple event
-    ical_events._ical_parser = AsyncMock(return_value=[{
-        "summary": "Test Event 1",
-        "start": datetime(2023, 1, 1, 12, 0, 0, tzinfo=timezone.utc),
-        "end": datetime(2023, 1, 1, 13, 0, 0, tzinfo=timezone.utc),
-        "location": "Test Location",
-        "description": "This is a test event",
-        "all_day": False
-    }])
-    
+    ical_events._ical_parser = AsyncMock(
+        return_value=[
+            {
+                "summary": "Test Event 1",
+                "start": datetime(2023, 1, 1, 12, 0, 0, tzinfo=timezone.utc),
+                "end": datetime(2023, 1, 1, 13, 0, 0, tzinfo=timezone.utc),
+                "location": "Test Location",
+                "description": "This is a test event",
+                "all_day": False,
+            }
+        ]
+    )
+
     await ical_events.update()
-    
+
     # Verify that the calendar was updated
     assert len(ical_events.calendar) == 1
     assert ical_events.calendar[0]["summary"] == "Test Event 1"
@@ -133,34 +93,36 @@ END:VCALENDAR"""
 async def test_async_get_events(mock_hass, basic_config):
     """Test async_get_events method."""
     ical_events = ICalEvents(hass=mock_hass, config=basic_config)
-    
+
     # Set up some test events
     start_date = datetime(2023, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
     end_date = datetime(2023, 1, 2, 0, 0, 0, tzinfo=timezone.utc)
-    
-    ical_events.calendar = [{
-        "summary": "Test Event 1",
-        "start": datetime(2023, 1, 1, 12, 0, 0, tzinfo=timezone.utc),
-        "end": datetime(2023, 1, 1, 13, 0, 0, tzinfo=timezone.utc),
-        "location": "Test Location",
-        "description": "This is a test event",
-        "all_day": False
-    }]
-    
+
+    ical_events.calendar = [
+        {
+            "summary": "Test Event 1",
+            "start": datetime(2023, 1, 1, 12, 0, 0, tzinfo=timezone.utc),
+            "end": datetime(2023, 1, 1, 13, 0, 0, tzinfo=timezone.utc),
+            "location": "Test Location",
+            "description": "This is a test event",
+            "all_day": False,
+        }
+    ]
+
     # Mock the CalendarEvent class to avoid timezone validation issues
-    with patch('custom_components.ical.CalendarEvent') as mock_calendar_event:
+    with patch("custom_components.ical.CalendarEvent") as mock_calendar_event:
         mock_event_instance = MagicMock()
         mock_calendar_event.return_value = mock_event_instance
-        
+
         events = await ical_events.async_get_events(mock_hass, start_date, end_date)
-        
+
         assert len(events) == 1
         mock_calendar_event.assert_called_once_with(
             datetime(2023, 1, 1, 12, 0, 0, tzinfo=timezone.utc),
             datetime(2023, 1, 1, 13, 0, 0, tzinfo=timezone.utc),
             "Test Event 1",
             "This is a test event",
-            "Test Location"
+            "Test Location",
         )
 
 
@@ -168,17 +130,17 @@ async def test_async_get_events(mock_hass, basic_config):
 async def test_ical_event_dict_with_past_event(mock_hass, basic_config):
     """Test _ical_event_dict with past event."""
     ical_events = ICalEvents(hass=mock_hass, config=basic_config)
-    
+
     from_date = datetime(2023, 1, 2, 0, 0, 0, tzinfo=timezone.utc)
     start = datetime(2023, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
     end = datetime(2023, 1, 1, 13, 0, 0, tzinfo=timezone.utc)
-    
+
     # Create a mock event
     event = MagicMock()
     event.get.return_value = "Past Event"
-    
+
     result = ical_events._ical_event_dict(start, end, from_date, event)
-    
+
     # Should return None for past events
     assert result is None
 
@@ -187,22 +149,24 @@ async def test_ical_event_dict_with_past_event(mock_hass, basic_config):
 async def test_ical_event_dict_with_future_event(mock_hass, basic_config):
     """Test _ical_event_dict with future event."""
     ical_events = ICalEvents(hass=mock_hass, config=basic_config)
-    
+
     from_date = datetime(2023, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
     start = datetime(2023, 1, 2, 12, 0, 0, tzinfo=timezone.utc)
     end = datetime(2023, 1, 2, 13, 0, 0, tzinfo=timezone.utc)
-    
+
     # Create a mock event
     event = MagicMock()
-    event.get = MagicMock(side_effect=lambda key, default=None: {
-        "SUMMARY": "Future Event",
-        "LOCATION": "Test Location",
-        "DESCRIPTION": "This is a future event"
-    }.get(key, default))
-    
-    with patch('homeassistant.util.dt.DEFAULT_TIME_ZONE', timezone.utc):
+    event.get = MagicMock(
+        side_effect=lambda key, default=None: {
+            "SUMMARY": "Future Event",
+            "LOCATION": "Test Location",
+            "DESCRIPTION": "This is a future event",
+        }.get(key, default)
+    )
+
+    with patch("homeassistant.util.dt.DEFAULT_TIME_ZONE", timezone.utc):
         result = ical_events._ical_event_dict(start, end, from_date, event)
-    
+
         assert result is not None
         assert result["summary"] == "Future Event"
         assert result["location"] == "Test Location"
@@ -210,3 +174,92 @@ async def test_ical_event_dict_with_future_event(mock_hass, basic_config):
         # The start time should be timezone-aware
         assert result["start"].tzinfo is not None
         assert result["end"].tzinfo is not None
+
+
+def test_check_event_with_regular_event():
+    """Test check_event returns datetime for non-all-day events."""
+    dt = datetime(2023, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+    result = check_event(dt, all_day=False)
+    assert isinstance(result, datetime)
+    assert result == dt
+
+
+def test_check_event_with_all_day_event():
+    """Test check_event returns date for all-day events."""
+    dt = datetime(2023, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+    result = check_event(dt, all_day=True)
+    assert isinstance(result, date)
+    assert not isinstance(result, datetime)
+    assert result == date(2023, 1, 1)
+
+
+@pytest.mark.asyncio
+async def test_ical_event_dict_with_overnight_event(mock_hass, basic_config):
+    """Test _ical_event_dict skips events where end <= start (issue #160)."""
+    ical_events = ICalEvents(hass=mock_hass, config=basic_config)
+
+    from_date = datetime(2023, 9, 4, 0, 0, 0, tzinfo=timezone.utc)
+    # Overnight event where TZ conversion made end appear before start
+    start = datetime(2023, 9, 4, 22, 0, 0, tzinfo=timezone.utc)
+    end = datetime(2023, 9, 4, 6, 0, 0, tzinfo=timezone.utc)
+
+    event = MagicMock()
+    event.get = MagicMock(return_value="Overnight Event")
+
+    result = ical_events._ical_event_dict(start, end, from_date, event)
+
+    # Should return None because end is before start
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_ical_event_dict_with_zero_duration_event(mock_hass, basic_config):
+    """Test _ical_event_dict allows zero-duration events (end == start)."""
+    ical_events = ICalEvents(hass=mock_hass, config=basic_config)
+
+    from_date = datetime(2023, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+    start = datetime(2023, 1, 2, 12, 0, 0, tzinfo=timezone.utc)
+    end = datetime(2023, 1, 2, 12, 0, 0, tzinfo=timezone.utc)
+
+    event = MagicMock()
+    event.get = MagicMock(return_value="Zero Duration Event")
+
+    with patch("homeassistant.util.dt.DEFAULT_TIME_ZONE", timezone.utc):
+        result = ical_events._ical_event_dict(start, end, from_date, event)
+
+    # Zero-duration events should be allowed (end == start is OK)
+    assert result is not None
+    assert result["summary"] == "Zero Duration Event"
+
+
+@pytest.mark.asyncio
+async def test_async_get_events_all_day(mock_hass, basic_config):
+    """Test async_get_events passes date objects for all-day events."""
+    ical_events = ICalEvents(hass=mock_hass, config=basic_config)
+
+    start_date = datetime(2023, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+    end_date = datetime(2023, 1, 3, 0, 0, 0, tzinfo=timezone.utc)
+
+    ical_events.calendar = [
+        {
+            "summary": "All Day Event",
+            "start": datetime(2023, 1, 1, 0, 0, 0, tzinfo=timezone.utc),
+            "end": datetime(2023, 1, 2, 0, 0, 0, tzinfo=timezone.utc),
+            "location": None,
+            "description": None,
+            "all_day": True,
+        }
+    ]
+
+    with patch("custom_components.ical.CalendarEvent") as mock_calendar_event:
+        mock_calendar_event.return_value = MagicMock()
+
+        events = await ical_events.async_get_events(mock_hass, start_date, end_date)
+
+        assert len(events) == 1
+        # check_event should convert to date objects for all-day events
+        call_args = mock_calendar_event.call_args[0]
+        assert isinstance(call_args[0], date)
+        assert not isinstance(call_args[0], datetime)
+        assert isinstance(call_args[1], date)
+        assert not isinstance(call_args[1], datetime)


### PR DESCRIPTION
## Summary

- Replace ~320 lines of manual RRULE expansion code in `_ical_parser` with the `recurring-ical-events` library (v3.8.0), which handles RRULE, EXDATE, RDATE, timezone edge cases, and broken iCal implementations
- Remove `_ical_date_fixer` and `_date_replace` helper methods (no longer needed)
- Change `end <= start` to `end < start` in `_ical_event_dict` to allow zero-duration events
- Add `check_event` helper for all-day date/datetime conversion in `CalendarEvent` construction
- Pin `icalendar>=6.1.0,<7.0.0` for compatibility, add `recurring-ical-events>=3.8.0`
- Update tests: remove obsolete `_ical_date_fixer` tests, update zero-duration event test, clean up unused imports

This builds on #161 and addresses the root cause of issues like #160 (overnight events) and the all-day RRULE end==start bug — rather than patching around them, we delegate to a well-tested library that handles all the edge cases.

## Test plan

- [x] All 37 tests pass (`pytest tests/ -v`)
- [x] Ruff + black clean
- [x] Tested in production Home Assistant instance with 5 live iCal calendars — no errors in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)