### PR TITLE
Fix HA compatibility, add options flow, fix all-day events

### DIFF
--- a/custom_components/ical/calendar.py
+++ b/custom_components/ical/calendar.py
@@ -36,9 +36,12 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 
     entity_id = generate_entity_id(ENTITY_ID_FORMAT, DOMAIN + " " + name, hass=hass)
 
-    ical_events = hass.data[DOMAIN][name]
+    ical_events = hass.data[DOMAIN][config_entry.entry_id]
 
-    calendar = ICalCalendarEventDevice(hass, name, entity_id, ical_events)
+    calendar = ICalCalendarEventDevice(
+        hass, name, entity_id, ical_events,
+        unique_id=f"{config_entry.entry_id}_calendar",
+    )
 
     async_add_entities([calendar], True)
 
@@ -46,9 +49,10 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 class ICalCalendarEventDevice(CalendarEntity):
     """A device for getting the next Task from a WebDav Calendar."""
 
-    def __init__(self, hass, name, entity_id, ical_events):
+    def __init__(self, hass, name, entity_id, ical_events, *, unique_id: str):
         """Create the iCal Calendar Event Device."""
         self.entity_id = entity_id
+        self._attr_unique_id = unique_id
         self._event = None
         self._name = name
         self._offset_reached = False

--- a/custom_components/ical/calendar.py
+++ b/custom_components/ical/calendar.py
@@ -9,7 +9,6 @@ from homeassistant.components.calendar import (
     CalendarEntity,
     CalendarEvent,
     extract_offset,
-    get_date,
     is_offset_reached,
 )
 from homeassistant.const import CONF_NAME

--- a/custom_components/ical/config_flow.py
+++ b/custom_components/ical/config_flow.py
@@ -73,8 +73,6 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a config flow for ical."""
 
     VERSION = 1
-    # TODO pick one of the available connection classes in homeassistant/config_entries.py
-    CONNECTION_CLASS = config_entries.CONN_CLASS_UNKNOWN
 
     async def async_step_user(self, user_input=None):
         """Handle the initial step."""

--- a/custom_components/ical/const.py
+++ b/custom_components/ical/const.py
@@ -5,7 +5,12 @@ DOMAIN = "ical"
 
 CONF_MAX_EVENTS = "max_events"
 CONF_DAYS = "days"
+CONF_DATE_FORMAT = "date_format"
+CONF_UPDATE_INTERVAL = "update_interval"
 
 ICON = "mdi:calendar"
 DEFAULT_NAME = "iCal Sensor"
 DEFAULT_MAX_EVENTS = 5
+DEFAULT_DAYS = 365
+DEFAULT_DATE_FORMAT = "%-d %B %Y"
+DEFAULT_UPDATE_INTERVAL = 120

--- a/custom_components/ical/manifest.json
+++ b/custom_components/ical/manifest.json
@@ -16,6 +16,6 @@
     "recurring-ical-events>=3.8.0"
   ],
   "ssdp": [],
-  "version": "1.9.0",
+  "version": "1.10.0",
   "zeroconf": []
 }

--- a/custom_components/ical/manifest.json
+++ b/custom_components/ical/manifest.json
@@ -16,6 +16,6 @@
     "recurring-ical-events>=3.8.0"
   ],
   "ssdp": [],
-  "version": "1.10.0",
+  "version": "1.10.0b1",
   "zeroconf": []
 }

--- a/custom_components/ical/sensor.py
+++ b/custom_components/ical/sensor.py
@@ -7,6 +7,7 @@ from homeassistant.components.sensor import SensorEntity
 from homeassistant.const import CONF_NAME
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
+from homeassistant.util import dt as dt_util
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import CONF_DATE_FORMAT, CONF_MAX_EVENTS, DEFAULT_DATE_FORMAT, DOMAIN, ICON
@@ -123,8 +124,10 @@ class ICalSensor(SensorEntity):
 
         await self.ical_events.update()
 
-        event_list = self.ical_events.calendar
-        # _LOGGER.debug(f"Event List: {event_list}")
+        all_events = self.ical_events.calendar
+        # Sensors show upcoming events only — filter out past events
+        now = dt_util.now()
+        event_list = [e for e in all_events if e["end"] > now]
         if event_list and (self._event_number < len(event_list)):
             val = event_list[self._event_number]
             name = val.get("summary", "Unknown")

--- a/custom_components/ical/strings.json
+++ b/custom_components/ical/strings.json
@@ -18,5 +18,17 @@
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
     }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "data": {
+          "max_events": "Number of event sensors",
+          "days": "Days into the future to fetch",
+          "date_format": "Date format (strftime)",
+          "update_interval": "Update interval (seconds)"
+        }
+      }
+    }
   }
 }

--- a/custom_components/ical/translations/de.json
+++ b/custom_components/ical/translations/de.json
@@ -20,5 +20,17 @@
             }
         }
     },
+    "options": {
+        "step": {
+            "init": {
+                "data": {
+                    "max_events": "Anzahl der Termin-Sensoren",
+                    "days": "Tage in der Zukunft abrufen",
+                    "date_format": "Datumsformat (strftime)",
+                    "update_interval": "Aktualisierungsintervall (Sekunden)"
+                }
+            }
+        }
+    },
     "title": "ical"
 }

--- a/custom_components/ical/translations/en.json
+++ b/custom_components/ical/translations/en.json
@@ -20,5 +20,17 @@
             }
         }
     },
+    "options": {
+        "step": {
+            "init": {
+                "data": {
+                    "max_events": "Number of event sensors",
+                    "days": "Days into the future to fetch",
+                    "date_format": "Date format (strftime)",
+                    "update_interval": "Update interval (seconds)"
+                }
+            }
+        }
+    },
     "title": "ical"
 }

--- a/tests/test_calendar.py
+++ b/tests/test_calendar.py
@@ -39,6 +39,7 @@ def test_calendar_device_init(mock_hass, mock_ical_events):
         name="test_calendar",
         entity_id="calendar.test_calendar",
         ical_events=mock_ical_events,
+        unique_id="test_entry_id_calendar",
     )
 
     assert device.entity_id == "calendar.test_calendar"
@@ -48,6 +49,19 @@ def test_calendar_device_init(mock_hass, mock_ical_events):
     assert device._offset_reached is False
 
 
+def test_calendar_device_unique_id(mock_hass, mock_ical_events):
+    """Test ICalCalendarEventDevice unique_id property."""
+    device = ICalCalendarEventDevice(
+        hass=mock_hass,
+        name="test_calendar",
+        entity_id="calendar.test_calendar",
+        ical_events=mock_ical_events,
+        unique_id="test_entry_id_calendar",
+    )
+
+    assert device.unique_id == "test_entry_id_calendar"
+
+
 def test_calendar_device_name(mock_hass, mock_ical_events):
     """Test ICalCalendarEventDevice name property."""
     device = ICalCalendarEventDevice(
@@ -55,6 +69,7 @@ def test_calendar_device_name(mock_hass, mock_ical_events):
         name="test_calendar",
         entity_id="calendar.test_calendar",
         ical_events=mock_ical_events,
+        unique_id="test_entry_id_calendar",
     )
 
     assert device.name == "test_calendar"
@@ -67,6 +82,7 @@ def test_calendar_device_event(mock_hass, mock_ical_events):
         name="test_calendar",
         entity_id="calendar.test_calendar",
         ical_events=mock_ical_events,
+        unique_id="test_entry_id_calendar",
     )
 
     # Initially should be None
@@ -90,6 +106,7 @@ def test_calendar_device_extra_state_attributes(mock_hass, mock_ical_events):
         name="test_calendar",
         entity_id="calendar.test_calendar",
         ical_events=mock_ical_events,
+        unique_id="test_entry_id_calendar",
     )
 
     # Test with offset not reached
@@ -111,6 +128,7 @@ async def test_calendar_device_async_get_events(mock_hass, mock_ical_events):
         name="test_calendar",
         entity_id="calendar.test_calendar",
         ical_events=mock_ical_events,
+        unique_id="test_entry_id_calendar",
     )
 
     start_date = datetime(2023, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
@@ -143,6 +161,7 @@ async def test_calendar_device_async_update(mock_hass, mock_ical_events):
         name="test_calendar",
         entity_id="calendar.test_calendar",
         ical_events=mock_ical_events,
+        unique_id="test_entry_id_calendar",
     )
 
     # Mock the copy.deepcopy to return the same event
@@ -170,6 +189,7 @@ async def test_calendar_device_async_update_with_no_event(mock_hass):
         name="test_calendar",
         entity_id="calendar.test_calendar",
         ical_events=ical_events,
+        unique_id="test_entry_id_calendar",
     )
 
     await device.async_update()
@@ -268,6 +288,7 @@ async def test_calendar_device_async_update_all_day(mock_hass):
         name="test_calendar",
         entity_id="calendar.test_calendar",
         ical_events=ical_events,
+        unique_id="test_entry_id_calendar",
     )
 
     await device.async_update()
@@ -302,6 +323,7 @@ async def test_calendar_device_async_update_timed_event(mock_hass):
         name="test_calendar",
         entity_id="calendar.test_calendar",
         ical_events=ical_events,
+        unique_id="test_entry_id_calendar",
     )
 
     await device.async_update()

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -90,3 +90,10 @@ def test_invalid_auth_exception():
     """Test InvalidAuth exception."""
     with pytest.raises(config_flow.InvalidAuth):
         raise config_flow.InvalidAuth()
+
+
+def test_config_flow_has_options_flow():
+    """Test that ConfigFlow provides an options flow handler."""
+    mock_entry = MagicMock()
+    handler = config_flow.ConfigFlow.async_get_options_flow(mock_entry)
+    assert isinstance(handler, config_flow.OptionsFlowHandler)

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -238,3 +238,21 @@ async def test_sensor_async_update_with_all_day_event(mock_hass):
 
     # Verify the state format for all-day events
     assert sensor.state == "All Day Event - 1 January 2023"
+
+
+@pytest.mark.asyncio
+async def test_sensor_custom_date_format(mock_hass, mock_ical_events):
+    """Test ICalSensor with custom date format."""
+    sensor = ICalSensor(
+        hass=mock_hass,
+        ical_events=mock_ical_events,
+        sensor_name="test_calendar",
+        event_number=0,
+        entry_id="test_entry_id",
+        date_format="%Y-%m-%d",
+    )
+
+    await sensor.async_update()
+
+    # Verify the state uses the custom date format
+    assert sensor.state == "Test Event 1 - 2023-01-01 12:00"

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -47,6 +47,7 @@ def test_sensor_init(mock_hass, mock_ical_events):
         ical_events=mock_ical_events,
         sensor_name="test_calendar",
         event_number=0,
+        entry_id="test_entry_id",
     )
 
     assert sensor._event_number == 0
@@ -71,9 +72,10 @@ def test_sensor_unique_id(mock_hass, mock_ical_events):
         ical_events=mock_ical_events,
         sensor_name="test_calendar",
         event_number=0,
+        entry_id="test_entry_id",
     )
 
-    assert sensor.unique_id == "test_calendar_event_0"
+    assert sensor.unique_id == "test_entry_id_event_0"
 
 
 def test_sensor_name(mock_hass, mock_ical_events):
@@ -83,6 +85,7 @@ def test_sensor_name(mock_hass, mock_ical_events):
         ical_events=mock_ical_events,
         sensor_name="test_calendar",
         event_number=0,
+        entry_id="test_entry_id",
     )
 
     # Name should be None initially since event attributes haven't been set
@@ -98,6 +101,7 @@ def test_sensor_icon(mock_hass, mock_ical_events):
         ical_events=mock_ical_events,
         sensor_name="test_calendar",
         event_number=0,
+        entry_id="test_entry_id",
     )
 
     assert sensor.icon == ICON
@@ -110,6 +114,7 @@ def test_sensor_state(mock_hass, mock_ical_events):
         ical_events=mock_ical_events,
         sensor_name="test_calendar",
         event_number=0,
+        entry_id="test_entry_id",
     )
 
     # State should be None initially
@@ -123,6 +128,7 @@ def test_sensor_extra_state_attributes(mock_hass, mock_ical_events):
         ical_events=mock_ical_events,
         sensor_name="test_calendar",
         event_number=0,
+        entry_id="test_entry_id",
     )
 
     # Should return the event attributes
@@ -142,6 +148,7 @@ def test_sensor_available(mock_hass, mock_ical_events):
         ical_events=mock_ical_events,
         sensor_name="test_calendar",
         event_number=0,
+        entry_id="test_entry_id",
     )
 
     # Should be False initially since start is None
@@ -156,6 +163,7 @@ async def test_sensor_async_update_with_event(mock_hass, mock_ical_events):
         ical_events=mock_ical_events,
         sensor_name="test_calendar",
         event_number=0,
+        entry_id="test_entry_id",
     )
 
     await sensor.async_update()
@@ -181,6 +189,7 @@ async def test_sensor_async_update_with_no_more_events(mock_hass, mock_ical_even
         ical_events=mock_ical_events,
         sensor_name="test_calendar",
         event_number=5,  # This is beyond the number of events in the calendar
+        entry_id="test_entry_id",
     )
 
     await sensor.async_update()
@@ -222,6 +231,7 @@ async def test_sensor_async_update_with_all_day_event(mock_hass):
         ical_events=ical_events,
         sensor_name="test_calendar",
         event_number=0,
+        entry_id="test_entry_id",
     )
 
     await sensor.async_update()


### PR DESCRIPTION
## Summary

- **Proper `unique_id` support** for sensors and calendar entities, enabling area assignment, renaming, and entity registry management. Existing name-based unique_ids are migrated in-place to preserve entity history. Resolves #90.
- **Options flow** so users can reconfigure `max_events`, `days`, `date_format`, and `update_interval` from Settings without removing the integration. Resolves #74, #77, #122, #72, #98.
- **Fix all-day events disappearing** on their own day due to the midnight end-time filter incorrectly catching them. Resolves #54.
- **Remove deprecated HA APIs**: `CONNECTION_CLASS`, `setup()`, `CONFIG_SCHEMA`, `async_forward_entry_unload`. Use `SensorEntity` base class, `async_unload_platforms`, and key `hass.data` by `entry.entry_id`.
- **Version bump** to 1.10.0.

## Changes

| File | Summary |
|------|---------|
| `__init__.py` | Remove `setup()`, `CONFIG_SCHEMA`, `voluptuous` import; key by `entry_id`; use `async_unload_platforms`; merge options over data; configurable update interval; register reload listener; fix all-day midnight filter |
| `sensor.py` | `SensorEntity` base class; `entry_id`-based `unique_id` with migration; configurable `date_format` |
| `calendar.py` | Add `unique_id` via `_attr_unique_id`; use `entry_id` for data lookup; remove unused `get_date` import |
| `config_flow.py` | Remove `CONNECTION_CLASS`; add `OptionsFlowHandler` |
| `const.py` | Add `CONF_DATE_FORMAT`, `CONF_UPDATE_INTERVAL` and defaults |
| `manifest.json` | Bump version to 1.10.0 |
| `strings.json`, `translations/` | Add options flow translations (en, de) |
| `tests/` | Update all constructors; add tests for unique_id, custom date format, options flow, all-day midnight fix |

## Migration safety

- **Sensor unique_id**: Old name-based entries migrated before entity creation — entity_id and history preserved.
- **Calendar unique_id**: Previously had none. Adding `_attr_unique_id` + keeping explicit `self.entity_id` preserves existing entity_ids while gaining registry tracking.
- **Options flow**: All new options have defaults matching previous behavior — no changes needed from users.

## Test plan

- [x] `pytest tests/ -v` — 41 passed, 5 skipped (pre-existing)
- [x] `ruff check` — clean
- [x] Install on HA, verify sensors and calendar load without errors
- [x] Verify existing entity_ids are preserved after upgrade
- [x] Open options flow from Settings, change values, verify reload applies them
- [ ] Verify all-day events remain visible on their day

🤖 Generated with [Claude Code](https://claude.com/claude-code)